### PR TITLE
Update serializers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,30 +1213,20 @@
       }
     },
     "@natlibfi/marc-record-validators-melinda": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-8.2.5.tgz",
-      "integrity": "sha512-lyYDS1io9MD6bD2vMYDs5c6tun+bUIcJ2ai0iXQhWY7NkRpD4XU/buQiddyC2OUC1NAhYkZ6nJKaj3hQh/4hQw==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-8.2.9.tgz",
+      "integrity": "sha512-4J8vTq4z0Q6IJ6CFfPaMB2BE+icISMLwCi2S5KFb8Al5piz6QsgC0jVDPueKKldE+gVIRYmiNu7HFiDr26MSTA==",
       "requires": {
         "@babel/register": "^7.6.2",
         "@natlibfi/issn-verify": "^1.0.0",
-        "@natlibfi/marc-record": "^4.0.4",
-        "beautify-isbn": "^2.2.0",
+        "@natlibfi/marc-record": "^6.0.1",
         "cld3-asm": "^3.1.1",
         "debug": "^4.1.1",
+        "isbn3": "^1.1.6",
         "langs": "^2.0.0",
         "lodash": "^4.17.11",
         "node-fetch": "^2.3.0",
         "xml2js": ">=0.4.19 <1.0.0"
-      },
-      "dependencies": {
-        "@natlibfi/marc-record": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-4.0.4.tgz",
-          "integrity": "sha512-XykLi0qevkLAVgLmRhATuyaSKgKczlgsk0JYCVUZAfKOHDJpb176uTQaVnQQtWe57CDPg02meAK1fTjlUNNR1Q==",
-          "requires": {
-            "jsonschema": "^1.2.4"
-          }
-        }
       }
     },
     "@natlibfi/melinda-backend-commons": {
@@ -1269,13 +1259,13 @@
       }
     },
     "@natlibfi/melinda-rest-api-commons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-1.0.2.tgz",
-      "integrity": "sha512-/mejDiMKspexeEVfSS1koYPnGAsrMCQDp9XZYaIOWzmW7ZRP97/fwhFOHlaizCYfuR4EqVOQ2PK8y4DRrLL/uA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-1.0.4.tgz",
+      "integrity": "sha512-uaVRFc9hZjIpcoAUpXfXw1c68JfmAqjfmE9/4BylhniFCBH+wIsbyjftRRT+GjC8b/H77ASS63RLwn1AqmUv7Q==",
       "requires": {
         "@natlibfi/fixura": "^2.1.3",
         "@natlibfi/marc-record": "^6.1.1",
-        "@natlibfi/marc-record-serializers": "^7.2.1",
+        "@natlibfi/marc-record-serializers": "^7.2.4",
         "@natlibfi/marc-record-validate": "^6.0.1",
         "@natlibfi/marc-record-validators-melinda": "^8.2.5",
         "@natlibfi/melinda-backend-commons": "^2.0.2",
@@ -1285,24 +1275,6 @@
         "moment": "^2.29.1",
         "mongo-sanitize": "^1.1.0",
         "mongodb": "^3.6.2"
-      },
-      "dependencies": {
-        "@natlibfi/melinda-commons": {
-          "version": "11.1.2",
-          "resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-11.1.2.tgz",
-          "integrity": "sha512-uBWvkgvN1zFxqmZRYecGMEnDQzwyPozJIuAPpSHSJoTqdCqMyt/uEcPT2IuuJLJsmfrLxnaUVdCm/ClZy5GJcQ==",
-          "requires": {
-            "@natlibfi/marc-record": "^6.0.4",
-            "@natlibfi/marc-record-serializers": "^7.2.4",
-            "@natlibfi/sru-client": "^4.0.2",
-            "debug": "^4.1.1",
-            "deep-eql": "^4.0.0",
-            "http-status": "^1.4.2",
-            "moment": "^2.27.0",
-            "nock": "^13.0.3",
-            "node-fetch": "^2.6.1"
-          }
-        }
       }
     },
     "@natlibfi/sru-client": {
@@ -1449,16 +1421,16 @@
       }
     },
     "amqplib": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.6.0.tgz",
-      "integrity": "sha512-zXCh4jQ77TBZe1YtvZ1n7sUxnTjnNagpy8MVi2yc1ive239pS3iLwm4e4d5o4XZGx1BdTKQ/U0ZmaDU3c8MxYQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.7.1.tgz",
+      "integrity": "sha512-KePK3tTOLGU4emTo+PwSDMbc123jrxo13FpRpim1LzJoSlQrIBB2/kMeCC40jK/Zb0olHGaABjLqXDsdK46iLA==",
       "requires": {
         "bitsyntax": "~0.1.0",
-        "bluebird": "^3.5.2",
+        "bluebird": "^3.7.2",
         "buffer-more-ints": "~1.0.0",
         "readable-stream": "1.x >=1.1.9",
-        "safe-buffer": "~5.1.2",
-        "url-parse": "~1.4.3"
+        "safe-buffer": "~5.2.1",
+        "url-parse": "~1.5.1"
       },
       "dependencies": {
         "isarray": {
@@ -1476,11 +1448,6 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1805,11 +1772,6 @@
       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
       "integrity": "sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q=="
     },
-    "beautify-isbn": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/beautify-isbn/-/beautify-isbn-2.2.0.tgz",
-      "integrity": "sha1-zWX/qv9bLCiU08W0eJkBakmL0HY="
-    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -1982,9 +1944,9 @@
       }
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -2763,9 +2725,9 @@
       }
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depcheck": {
       "version": "0.8.3",
@@ -4555,6 +4517,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isbn3": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.10.tgz",
+      "integrity": "sha512-kjVSMmcXzLQfG2xuB+7+JL5rRArU093tFIMK6PL1913C3TNQWL/mBsAnHIAPvWhj3xUDO19MW6gRulYjw7WcBg=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4937,14 +4904,14 @@
       "integrity": "sha512-6gB9AiJD+om2eZLxaPKIP5Q8P3Fr+s+17rVWso7hU0+MAzmIvIMlgTYuyvalDLTtE/p0gczcvJ8A3pbN1XmQ/A=="
     },
     "mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
+      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.0.2",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
@@ -5896,6 +5863,11 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "optional-require": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -6557,15 +6529,6 @@
       "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6590,11 +6553,6 @@
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -7584,9 +7542,9 @@
       "optional": true
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,16 +1190,16 @@
       }
     },
     "@natlibfi/marc-record-serializers": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-7.2.1.tgz",
-      "integrity": "sha512-+cs8lBbu9fNvHPT59xESBxNaziqtze1rtCdMzYCkQC4dIwHAIGPd6x2Hkx1vPqHhp5IBP05OckePmI4J5h4RZA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-7.2.4.tgz",
+      "integrity": "sha512-otCKIbb0LNMcLJ9p4HKsOgjw0NW7odyeTr9WUdJMD/8TWjAIuzPRq4tGADD9tVUqIfyhCGIFeXTun+/5wmvqog==",
       "requires": {
         "@natlibfi/marc-record": "^6.0.3",
         "ora": "^5.0.0",
         "stream-json": "^1.7.1",
         "text-encoding": "^0.7.0",
         "xml2js": "^0.4.23",
-        "xmldom": "^0.3.0",
+        "xmldom": "^0.5.0",
         "yargs": "^15.4.1"
       }
     },
@@ -1253,12 +1253,12 @@
       }
     },
     "@natlibfi/melinda-commons": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-11.1.1.tgz",
-      "integrity": "sha512-WX6h0GOw/n06B8kBC2eY0649LsKYb4Y+YGfjp3aG9SyzZCSlV6JVgtlViuPh/d7HiTZEU59sjsrQiVT5emQn6w==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-11.1.2.tgz",
+      "integrity": "sha512-uBWvkgvN1zFxqmZRYecGMEnDQzwyPozJIuAPpSHSJoTqdCqMyt/uEcPT2IuuJLJsmfrLxnaUVdCm/ClZy5GJcQ==",
       "requires": {
         "@natlibfi/marc-record": "^6.0.4",
-        "@natlibfi/marc-record-serializers": "^7.1.4",
+        "@natlibfi/marc-record-serializers": "^7.2.4",
         "@natlibfi/sru-client": "^4.0.2",
         "debug": "^4.1.1",
         "deep-eql": "^4.0.0",
@@ -1285,6 +1285,24 @@
         "moment": "^2.29.1",
         "mongo-sanitize": "^1.1.0",
         "mongodb": "^3.6.2"
+      },
+      "dependencies": {
+        "@natlibfi/melinda-commons": {
+          "version": "11.1.2",
+          "resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-11.1.2.tgz",
+          "integrity": "sha512-uBWvkgvN1zFxqmZRYecGMEnDQzwyPozJIuAPpSHSJoTqdCqMyt/uEcPT2IuuJLJsmfrLxnaUVdCm/ClZy5GJcQ==",
+          "requires": {
+            "@natlibfi/marc-record": "^6.0.4",
+            "@natlibfi/marc-record-serializers": "^7.2.4",
+            "@natlibfi/sru-client": "^4.0.2",
+            "debug": "^4.1.1",
+            "deep-eql": "^4.0.0",
+            "http-status": "^1.4.2",
+            "moment": "^2.27.0",
+            "nock": "^13.0.3",
+            "node-fetch": "^2.6.1"
+          }
+        }
       }
     },
     "@natlibfi/sru-client": {
@@ -1777,6 +1795,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "base64-url": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
@@ -1962,6 +1985,15 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2305,9 +2337,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
-      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q=="
     },
     "cli-width": {
       "version": "2.2.1",
@@ -4042,6 +4074,11 @@
       "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.5.0.tgz",
       "integrity": "sha512-wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg=="
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4109,9 +4146,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -4490,6 +4527,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4702,11 +4744,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
     "logform": {
@@ -4910,11 +4953,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanoid": {
       "version": "2.1.11",
@@ -5873,18 +5911,31 @@
       }
     },
     "ora": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
-      "integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.0.tgz",
+      "integrity": "sha512-1StwyXQGoU6gdjYkyVcqOLnVlbKj+6yPNNOxJVgpt9t4eksKjiriiHuxktLYkgllwk+D6MbC4ihH84L1udRXPg==",
       "requires": {
+        "bl": "^4.1.0",
         "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.4.0",
+        "cli-spinners": "^2.5.0",
         "is-interactive": "^1.0.0",
-        "log-symbols": "^4.0.0",
-        "mute-stream": "0.0.8",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        }
       }
     },
     "p-cancelable": {
@@ -7033,9 +7084,9 @@
       }
     },
     "stream-chain": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.3.tgz",
-      "integrity": "sha512-w+WgmCZ6BItPAD3/4HD1eDiDHRLhjSSyIV+F0kcmmRyz8Uv9hvQF22KyaiAUmOlmX3pJ6F95h+C191UbS8Oe/g=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.4.tgz",
+      "integrity": "sha512-9lsl3YM53V5N/I1C2uJtc3Kavyi3kNYN83VkKb/bMWRk7D9imiFyUPYa0PoZbLohSVOX1mYE9YsmwObZUsth6Q=="
     },
     "stream-json": {
       "version": "1.7.1",
@@ -7775,9 +7826,9 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmldom": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@natlibfi/marc-record": "^6.1.1",
-    "@natlibfi/marc-record-serializers": "^7.2.1",
+    "@natlibfi/marc-record-serializers": "^7.2.4",
     "@natlibfi/melinda-backend-commons": "^2.0.2",
-    "@natlibfi/melinda-commons": "^11.1.1",
-    "@natlibfi/melinda-rest-api-commons": "^1.0.2",
+    "@natlibfi/melinda-commons": "^11.1.2",
+    "@natlibfi/melinda-rest-api-commons": "^1.0.4",
     "esm": "^3.2.25",
     "http-status": "^1.4.2",
     "moment": "^2.29.1",


### PR DESCRIPTION
- Update https://www.npmjs.com/package/@natlibfi/marc-record-serializers to 7.2.4 which uses SE in FMT field for continuing resources as Aleph does instead of CR as Finnish MARC 21 translation does.

- Update deps