### PR TITLE
Handle z00 unique constraint errors (#72)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/melinda-rest-api-importer",
-  "version": "3.0.5",
+  "version": "3.0.6-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/melinda-rest-api-importer",
-      "version": "3.0.5",
+      "version": "3.0.6-alpha.1",
       "license": "AGPL-3.0+",
       "dependencies": {
         "@babel/runtime": "^7.20.13",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git@github.com:NatLibFi/melinda-rest-api-importer.git"
   },
   "license": "AGPL-3.0+",
-  "version": "3.0.5",
+  "version": "3.0.6-alpha.1",
   "main": "./dist/index.js",
   "engines": {
     "node": ">=18"

--- a/src/interfaces/processPoll.js
+++ b/src/interfaces/processPoll.js
@@ -41,32 +41,47 @@ export default function ({recordLoadApiKey, recordLoadUrl}) {
     }
 
     // response: {"status":200,"payload":{"handledIds":[],"rejectedIds":["000000001"],"rejectMessages": []}}
-    // response: {"status":409,"payload":{"handledIds":["000000001FIN01","000000002FIN01","000000004FIN01"],"rejectedIds":[],"rejectMessages": []}}
+    // response: {"status":409,"payload":{"handledIds":["000000001FIN01","000000002FIN01","000000004FIN01"],"rejectedIds":[],"rejectMessages": [], "errorIdCount": 1}}
 
     // 401, 403, 404, 406, 423, 503 responses from checkStatus
     checkStatus(response);
 
     // OK (200)
-    // R-L-A has crashed (409)
+    // R-L-A has crashed (409) or encountered one or more oraErrors
 
     if (response.status === httpStatus.OK || response.status === httpStatus.CONFLICT) {
-      const {handledIds, rejectedIds, rejectMessages} = await response.json();
-      logger.silly(`processPoll/poll handledIds: ${handledIds} rejectedIds: ${rejectedIds} rejectMessages: ${rejectMessages}`);
+      const {handledIds, rejectedIds, rejectMessages, errorIdCount} = await response.json();
+      // errorIdCount: amount ids that didn't get created even if their id is listed as handledIds
+      logger.silly(`processPoll/poll handledIds: ${handledIds} rejectedIds: ${rejectedIds} rejectMessages: ${rejectMessages}: errorIdCount: ${errorIdCount}`);
 
       // This should check that payloads make sense (ie. are arrays)
       const handledIdList = handledIds.map(id => formatRecordId(pActiveLibrary, id));
+
+      // Mark here those handledIds that are identical to the previous handledId as ERRORs
+      const handledIdListWithErrors = await handledIdList.map((id, index, array) => {
+        if (array[index - 1] === id) {
+          return `ERROR-${id}`;
+        }
+        return id;
+      });
+
       const rejectedIdList = rejectedIds.map(id => formatRecordId(pActiveLibrary, id));
 
       const handledAmount = handledIdList.length || 0;
       const rejectedAmount = rejectedIdList.length || 0;
-      const processedAmount = handledAmount + rejectedAmount;
+      // if we didn't get errorIdCount => erroredAmount = 0
+      const erroredAmount = errorIdCount || 0;
+      // errored records were NOT handled, even if they are listed in handledId list (Aleph updates syslog before trying to create the record)
+      const processedAmount = handledAmount + rejectedAmount - erroredAmount;
       const notProcessedAmout = recordAmount - processedAmount;
       const processedAll = processedAmount === recordAmount;
-      const handledAll = handledAmount === recordAmount;
+      const handledAll = handledAmount - erroredAmount === recordAmount;
 
-      logger.silly(`processPoll/poll recordAmount: ${recordAmount}, processedAmount: ${processedAmount}, notProcessedAmount: ${notProcessedAmout}`);
+      logger.silly(`processPoll/poll recordAmount: ${recordAmount}, processedAmount: ${processedAmount}, notProcessedAmount: ${notProcessedAmout}, erroredAmount: ${erroredAmount}`);
 
-      const loadProcessReport = {status: response.status, processId, loaderProcessId, processedAll, recordAmount, processedAmount, handledAmount, rejectedAmount, rejectMessages, handledAll};
+      logger.debug(`handledAmount: ${handledAmount}, erroredAmount: ${erroredAmount}`);
+
+      const loadProcessReport = {status: response.status, processId, loaderProcessId, processedAll, recordAmount, processedAmount, handledAmount, rejectedAmount, rejectMessages, erroredAmount, handledAll};
       const responseStatusString = response.status === httpStatus.OK ? '"OK" (200)' : '"CONFLICT" (409)';
       logger.silly(`processPoll/poll Created loadProcessReport: ${JSON.stringify(loadProcessReport)}`);
 
@@ -80,16 +95,16 @@ export default function ({recordLoadApiKey, recordLoadUrl}) {
       // Ack all messages for sent records
 
       // eslint-disable-next-line functional/no-conditional-statement
-      if (processedAmount === 0) {
-        logger.info(`Got ${responseStatusString} response from record-load-api, but NO records were processed ${processedAmount}/${recordAmount}. HandledIds (${handledIdList.length}). RejectedIds (${rejectedIdList.length})`);
+      if (processedAmount === 0 || processedAmount < 0) {
+        logger.info(`Got ${responseStatusString} response from record-load-api, but NO records were processed ${processedAmount}/${recordAmount}. HandledIds (${handledIdList.length}). RejectedIds (${rejectedIdList.length}). ErroredAmount: ${erroredAmount}`);
       }
       // eslint-disable-next-line functional/no-conditional-statement
       if (processedAmount > 0) {
-        logger.info(`Got ${responseStatusString} response from record-load-api, but all records were NOT processed ${processedAmount}/${recordAmount}. HandledIds (${handledIdList.length}). RejectedIds (${rejectedIdList.length})`);
+        logger.info(`Got ${responseStatusString} response from record-load-api, but all records were NOT processed ${processedAmount}/${recordAmount}. HandledIds (${handledIdList.length}). RejectedIds (${rejectedIdList.length}). ErroredAmount (${erroredAmount})`);
       }
 
-      logger.debug(`Ids (${handledIdList.length}): ${handledIdList}. RejectedIds (${rejectedIdList.length}): ${rejectedIdList}`);
-      return {payloads: {handledIds: handledIdList, rejectedIds: rejectedIdList, loadProcessReport}, ackOnlyLength: recordAmount};
+      logger.debug(`Ids (${handledIdListWithErrors.length}): ${handledIdListWithErrors}. RejectedIds (${rejectedIdList.length}): ${rejectedIdList}. ErroredAmount: ${erroredAmount}`);
+      return {payloads: {handledIds: handledIdListWithErrors, rejectedIds: rejectedIdList, erroredAmount, loadProcessReport}, ackOnlyLength: recordAmount};
     }
 
     // 500 from aleph-record-load-api goes here (not in utils::checkStatus)


### PR DESCRIPTION
* Handle erroredIdCount, which contains the amount of Oracle z00 unique constraint errors the job encountered, from the record-load-api in ProcessPoll 
* Recognize (later) duplicate id in handledIds as errorId, which resulted from the server encountering Oracle z00 unique constraint error and failing to create the record
* Return ERROR as recordStatus for records that had an errorId and were actually not created
* Return Service Unavailable (503) when a prio CREATE results in an erroredIdCount greater than zero

* 3.0.6-alpha.1